### PR TITLE
Tweak hash operation for eventdata

### DIFF
--- a/lib/fluent/plugin/parser_winevt_xml.rb
+++ b/lib/fluent/plugin/parser_winevt_xml.rb
@@ -26,7 +26,6 @@ module Fluent::Plugin
       record["Computer"]              = (system_elem/"Computer").text rescue nil
       record["UserID"]                = (system_elem/'Security').attribute("UserID").text rescue nil
       record["Version"]               = (system_elem/'Version').text rescue nil
-      record["EventData"]             = [] # These parameters are processed in winevt_c.
       time = @estimate_current_event ? Fluent::EventTime.now : nil
       yield time, record
     end

--- a/lib/fluent/plugin/parser_winevt_xml.rb
+++ b/lib/fluent/plugin/parser_winevt_xml.rb
@@ -26,6 +26,7 @@ module Fluent::Plugin
       record["Computer"]              = (system_elem/"Computer").text rescue nil
       record["UserID"]                = (system_elem/'Security').attribute("UserID").text rescue nil
       record["Version"]               = (system_elem/'Version').text rescue nil
+      record["InsertStrings"]         = [] # These parameters are processed in winevt_c.
       time = @estimate_current_event ? Fluent::EventTime.now : nil
       yield time, record
     end

--- a/test/plugin/test_parser_winevt_xml.rb
+++ b/test/plugin/test_parser_winevt_xml.rb
@@ -32,7 +32,8 @@ class WinevtXMLparserTest < Test::Unit::TestCase
                 "Channel"           => "Security",
                 "Computer"          => "Fluentd-Developing-Windows",
                 "UserID"            => nil,
-                "Version"           => "2",}
+                "Version"           => "2",
+                "InsertStrings"     => []}
     d.instance.parse(xml) do |time, record|
       assert_equal(expected, record)
     end

--- a/test/plugin/test_parser_winevt_xml.rb
+++ b/test/plugin/test_parser_winevt_xml.rb
@@ -32,8 +32,7 @@ class WinevtXMLparserTest < Test::Unit::TestCase
                 "Channel"           => "Security",
                 "Computer"          => "Fluentd-Developing-Windows",
                 "UserID"            => nil,
-                "Version"           => "2",
-                "EventData"         => []}
+                "Version"           => "2",}
     d.instance.parse(xml) do |time, record|
       assert_equal(expected, record)
     end


### PR DESCRIPTION
This change is needed to process XML rendered Windows EventLog in remote server.