### PR TITLE
Relax required version of nokogiri

### DIFF
--- a/fluent-plugin-parser-winevt_xml.gemspec
+++ b/fluent-plugin-parser-winevt_xml.gemspec
@@ -21,5 +21,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake"
   spec.add_development_dependency "test-unit", "~> 3.4.0"
   spec.add_runtime_dependency "fluentd", [">= 0.14.12", "< 2"]
-  spec.add_runtime_dependency "nokogiri", [">= 1.12.5", "< 1.14"]
+  spec.add_runtime_dependency "nokogiri", [">= 1.12.5", "< 1.15"]
 end


### PR DESCRIPTION
nokogiri 1.14.0 has been released, it seems compatible too.

Signed-off-by: Takuro Ashie <ashie@clear-code.com>