### PR TITLE
Relax required version of nokogiri

### DIFF
--- a/fluent-plugin-parser-winevt_xml.gemspec
+++ b/fluent-plugin-parser-winevt_xml.gemspec
@@ -21,5 +21,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake"
   spec.add_development_dependency "test-unit", "~> 3.4.0"
   spec.add_runtime_dependency "fluentd", [">= 0.14.12", "< 2"]
-  spec.add_runtime_dependency "nokogiri", [">= 1.12.5", "< 1.15"]
+  spec.add_runtime_dependency "nokogiri", [">= 1.12.5", "< 1.16"]
 end


### PR DESCRIPTION
bundle exec rake test pass with nokogiri 1.15.3.

![nokogiri-1 15 3](https://github.com/fluent/fluent-plugin-parser-winevt_xml/assets/225841/80546a86-f84f-4729-8f28-81ea3a7637c6)
