### PR TITLE
Allow nokogiri v1.16 series

### DIFF
--- a/fluent-plugin-parser-winevt_xml.gemspec
+++ b/fluent-plugin-parser-winevt_xml.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake"
   spec.add_development_dependency "test-unit", "~> 3.4.0"
   spec.add_runtime_dependency "fluentd", [">= 0.14.12", "< 2"]
-  spec.add_runtime_dependency "nokogiri", [">= 1.12.5", "< 1.16"]
+  spec.add_runtime_dependency "nokogiri", [">= 1.12.5", "< 1.17"]
 
   # gems that aren't default gems as of Ruby 3.4
   spec.add_runtime_dependency "base64", "~> 0.2"


### PR DESCRIPTION
Vendored libxml2 of nokogiri contains security fix (CVE-2024-25062) in v1.16.2