### PR TITLE
Bump version to 0.2.7

### DIFF
--- a/fluent-plugin-parser-winevt_xml.gemspec
+++ b/fluent-plugin-parser-winevt_xml.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
 Gem::Specification.new do |spec|
   spec.name          = "fluent-plugin-parser-winevt_xml"
-  spec.version       = "0.2.6"
+  spec.version       = "0.2.7"
   spec.authors       = ["Hiroshi Hatake", "Masahiro Nakagawa"]
   spec.email         = ["cosmo0920.oucc@gmail.com", "repeatedly@gmail.com"]
   spec.summary       = %q{Fluentd Parser plugin to parse XML rendered windows event log.}


### PR DESCRIPTION
* Bump actions/checkout from 3 to 4
* Add missing dependency for ruby head
* ci: add ruby 3.3 into test matrix
* Allow nokogiri v1.16 series (FYI: CVE-2024-25062)