### PR TITLE
Relax restriction of Nokogiri requirement

### DIFF
--- a/fluent-plugin-parser-winevt_xml.gemspec
+++ b/fluent-plugin-parser-winevt_xml.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake"
   spec.add_development_dependency "test-unit", "~> 3.4.0"
   spec.add_runtime_dependency "fluentd", [">= 0.14.12", "< 2"]
-  spec.add_runtime_dependency "nokogiri", [">= 1.12.5", "< 1.17"]
+  spec.add_runtime_dependency "nokogiri", ">= 1.12.5"
 
   # gems that aren't default gems as of Ruby 3.4
   spec.add_runtime_dependency "base64", "~> 0.2"


### PR DESCRIPTION
It makes hard to follow Nokogiri updates and no need to set upper limit now.


Passed:

Ruby 3.3 + Nokogiri 1.18.2
Ruby 3.2 + Nokogiri 1.18.2
Ruby 3.1 + Nokogiri 1.18.2
Ruby 3.0 + Nokogiri 1.17.2
Ruby 2.7 + Nokogiri 1.15.7
