### PR TITLE
Fix postposition rescue and if

### DIFF
--- a/lib/fluent/plugin/parser_winevt_xml.rb
+++ b/lib/fluent/plugin/parser_winevt_xml.rb
@@ -20,7 +20,9 @@ module Fluent::Plugin
     end
 
     def event_id(system_elem)
-      return (system_elem/'EventID').text rescue nil if @preserve_qualifiers
+      if @preserve_qualifiers
+        return (system_elem/'EventID').text rescue nil
+      end
 
       qualifiers = (system_elem/'EventID').attribute("Qualifiers").text rescue nil
       if qualifiers


### PR DESCRIPTION
When It use postposition `rescue` and `if` at same line, the behavior is changed since Ruby 3.4. 
https://bugs.ruby-lang.org/issues/21132