### PR TITLE
xml: fix incorrect use of rescue

### DIFF
--- a/lib/fluent/plugin/parser_winevt_xml.rb
+++ b/lib/fluent/plugin/parser_winevt_xml.rb
@@ -21,7 +21,7 @@ module Fluent::Plugin
 
     def event_id(system_elem)
       if @preserve_qualifiers
-        return (system_elem/'EventID').text rescue nil
+        return ((system_elem/'EventID').text rescue nil)
       end
 
       qualifiers = (system_elem/'EventID').attribute("Qualifiers").text rescue nil


### PR DESCRIPTION
To surely execute `return`, we need brackets.
Existing implementations try to perform useless processing without return when an exception occurs.