### PR TITLE
CI: Drop obsolete versions and head

### DIFF
--- a/.github/workflows/linux-test.yaml
+++ b/.github/workflows/linux-test.yaml
@@ -13,7 +13,7 @@ jobs:
     uses: ruby/actions/.github/workflows/ruby_versions.yml@master
     with:
       engine: cruby
-      min_version: 2.7
+      min_version: 3.2
   test:
     needs: ruby-versions
     runs-on: ${{ matrix.os }}
@@ -22,6 +22,8 @@ jobs:
       fail-fast: false
       matrix:
         ruby: ${{ fromJson(needs.ruby-versions.outputs.versions) }}
+        exclude:
+          - ruby: ${{ github.event_name != 'schedule' && 'head' || '__none__' }}
         os: [ubuntu-latest]
 
     name: Ruby ${{ matrix.ruby }} on ${{ matrix.os }}

--- a/.github/workflows/macos-test.yaml
+++ b/.github/workflows/macos-test.yaml
@@ -13,7 +13,7 @@ jobs:
     uses: ruby/actions/.github/workflows/ruby_versions.yml@master
     with:
       engine: cruby
-      min_version: 2.7
+      min_version: 3.2
   test:
     needs: ruby-versions
     runs-on: ${{ matrix.os }}
@@ -22,7 +22,7 @@ jobs:
       matrix:
         ruby: ${{ fromJson(needs.ruby-versions.outputs.versions) }}
         exclude:
-          - ruby: head
+          - ruby: ${{ github.event_name != 'schedule' && 'head' || '__none__' }}
         os: [macos-latest]
 
     name: Ruby ${{ matrix.ruby }} on ${{ matrix.os }}

--- a/.github/workflows/windows-test.yaml
+++ b/.github/workflows/windows-test.yaml
@@ -13,7 +13,7 @@ jobs:
     uses: ruby/actions/.github/workflows/ruby_versions.yml@master
     with:
       engine: cruby
-      min_version: 2.7
+      min_version: 3.2
   test:
     needs: ruby-versions
     runs-on: ${{ matrix.os }}
@@ -22,7 +22,7 @@ jobs:
       matrix:
         ruby: ${{ fromJson(needs.ruby-versions.outputs.versions) }}
         exclude:
-          - ruby: head
+          - ruby: ${{ github.event_name != 'schedule' && 'head' || '__none__' }}
         os:
           - windows-latest
     name: Ruby ${{ matrix.ruby }} on ${{ matrix.os }}


### PR DESCRIPTION
Run `head` monthly instead.